### PR TITLE
Remove Moo dependency from Duo::API::Iterator

### DIFF
--- a/lib/Duo/API.pm
+++ b/lib/Duo/API.pm
@@ -223,7 +223,7 @@ sub json_paging_api_call {
 
     # deep copy
     $params = decode_json(encode_json($params));
-    $params->{limit}  ||= $self->paging_limit;
+    $params->{limit}  ||= $self->{paging_limit};
 
     my @objects;
     $params->{offset} ||= 0;

--- a/lib/Duo/API/Iterator.pm
+++ b/lib/Duo/API/Iterator.pm
@@ -65,6 +65,7 @@ Returns: a list of all remaining items not yet returned by the generator.
 use warnings;
 use strict;
 use Carp qw(croak);
+use Scalar::Util qw(reftype);
 
 sub new {
     my ($class,%params) = @_;
@@ -72,7 +73,7 @@ sub new {
     croak "Missing required arguments: $g"
         unless exists $params{$g};
     croak "The $g parameter must be a subroutine reference."
-        unless ref($params{$g}) eq 'CODE';
+        unless reftype($params{$g}) || '' eq 'CODE';
     return bless { $g => $params{$g} }, $class;
 }
 

--- a/lib/Duo/API/Iterator.pm
+++ b/lib/Duo/API/Iterator.pm
@@ -1,6 +1,6 @@
 package Duo::API::Iterator;
 
-our $VERSION = '1.1';
+our $VERSION = '1.2';
 
 =head1 NAME
 
@@ -13,7 +13,7 @@ Duo::API::Iterator
     my $generator = sub {
         return shift @items;
     };
-    my $iter = Duo::API::Iterator(generator => $generator);
+    my $iter = Duo::API::Iterator->new(generator => $generator);
 
     my $first_item = $iter->next(); # 5
     my @remaining = $iter->all();   # (4, 3, 2, 1)
@@ -62,23 +62,23 @@ Returns: a list of all remaining items not yet returned by the generator.
 
 =cut
 
-use Moo;
+use warnings;
+use strict;
 use Carp qw(croak);
-use Scalar::Util qw(reftype);
 
-has 'generator' => (
-    is => 'ro',
-    isa => sub {
-        my $input = shift;
-        croak "The generator parameter must be a subroutine references."
-            unless reftype($input) eq 'CODE' 
-    },
-    required => 1
-);
+sub new {
+    my ($class,%params) = @_;
+    my $g = 'generator';
+    croak "Missing required arguments: $g"
+        unless exists $params{$g};
+    croak "The $g parameter must be a subroutine reference."
+        unless ref($params{$g}) eq 'CODE';
+    return bless { $g => $params{$g} }, $class;
+}
 
 sub next {
     my ($self) = @_;
-    return $self->generator->();
+    return $self->{generator}->();
 }
 
 sub all {


### PR DESCRIPTION
Only applies to 6cf797ae8c21d27026a4e703ff9c17e4568eabd2
(I'm still pretty new to git[hub] fork/merge/...)

A platform we run does not natively support Moo. To avoid having to install and maintain some ~2000 lines of dependent code for Moo, the dependency was removed and replaced with new().

Passes make test.