### PR TITLE
Fix request parameters to maintain list order.

### DIFF
--- a/lib/Duo/API.pm
+++ b/lib/Duo/API.pm
@@ -2,7 +2,7 @@ package Duo::API;
 use strict;
 use warnings;
 
-our $VERSION = '1.2';
+our $VERSION = '1.2.1';
 
 =head1 NAME
 

--- a/lib/Duo/API/Iterator.pm
+++ b/lib/Duo/API/Iterator.pm
@@ -1,6 +1,6 @@
 package Duo::API::Iterator;
 
-our $VERSION = '1.2';
+our $VERSION = '1.2.1';
 
 =head1 NAME
 

--- a/t/api_calls.t
+++ b/t/api_calls.t
@@ -282,7 +282,7 @@ describe "A duo api client" => sub {
                 'that=1&other=2&this=a&this=c&this=b',
             );
             my $is_correct = grep { $url_params eq $_ } @acceptable_forms;
-            ok($is_correct) || print ($is_correct, $url_params);
+            ok($is_correct);
         };
     };
 

--- a/t/api_calls.t
+++ b/t/api_calls.t
@@ -267,7 +267,7 @@ describe "A duo api client" => sub {
             is($url_params, "this=a&this=c&this=b");
 	};
 
-        it "products the expected parameter string for multiple params" => sub {
+        it "produces the expected parameter string for multiple params" => sub {
             my $url_params = $sut->encode_request_params({
                 this => ['a', 'c', 'b'],
                 that => 1,
@@ -294,7 +294,7 @@ describe "A duo api client" => sub {
             is($canon_params, "this=a&this=b&this=c");
 	};
 
-        it "products the expected parameter string for multiple params" => sub {
+        it "produces the expected parameter string for multiple params" => sub {
             my $url_params = $sut->canonicalize_params({
                 this => ['a', 'c', 'b'],
                 that => 1,

--- a/t/api_calls.t
+++ b/t/api_calls.t
@@ -259,6 +259,51 @@ describe "A duo api client" => sub {
         };
     };
 
+    describe "encode_request_params method" => sub {
+        it "produces the expected parameter string for list params" => sub {
+            my $url_params = $sut->encode_request_params({
+                this => ['a', 'c', 'b'],
+            });
+            is($url_params, "this=a&this=c&this=b");
+	};
+
+        it "products the expected parameter string for multiple params" => sub {
+            my $url_params = $sut->encode_request_params({
+                this => ['a', 'c', 'b'],
+                that => 1,
+                other => 2,
+            });
+            my @acceptable_forms = (
+                'this=a&this=c&this=b&that=1&other=2',
+                'this=a&this=c&this=b&other=2&that=1',
+                'other=2&this=a&this=c&this=b&that=1',
+                'other=2&that=1&this=a&this=c&this=b',
+                'that=1&this=a&this=c&this=b&other=2',
+                'that=1&other=2&this=a&this=c&this=b',
+            );
+            my $is_correct = grep { $url_params eq $_ } @acceptable_forms;
+            ok($is_correct) || print ($is_correct, $url_params);
+        };
+    };
+
+    describe "canonicalize_params method" => sub {
+        it "produces the expected parameter string for list params" => sub {
+            my $canon_params = $sut->canonicalize_params({
+                this => ['a', 'c', 'b'],
+            });
+            is($canon_params, "this=a&this=b&this=c");
+	};
+
+        it "products the expected parameter string for multiple params" => sub {
+            my $url_params = $sut->canonicalize_params({
+                this => ['a', 'c', 'b'],
+                that => 1,
+                other => 2,
+            });
+            is($url_params, 'other=2&that=1&this=a&this=b&this=c');
+        };
+    };
+
     describe "make_request method" => sub {
         my @sleep_calls;
         my @response_codes;


### PR DESCRIPTION
Encountered a problem where we sort the parameters for signature purposes and then pass those sorted arguments over to the api. The problem here is that for list arguments, order can be important. This is particularly the case when trying to interact with the auth log endpoints. If the timestamp gets sorted after the UUID in the next_offset argument, it results in an error from the server.