### PR TITLE
Add CA bundle version and pinning status

### DIFF
--- a/lib/Duo/API.pm
+++ b/lib/Duo/API.pm
@@ -4,6 +4,7 @@ use warnings;
 
 our $VERSION = '1.4.0';
 our $APP_NAME = 'duo_api_perl';
+our $CA_BUNDLE_VERSION = '1.0';
 
 =head1 NAME
 
@@ -212,7 +213,8 @@ sub api_call {
     $req->header('Authorization' => $auth);
     $req->header('Date' => $date);
     $req->header('Host' => $self->{'host'});
-    $req->header('User-Agent' => $APP_NAME . "/" . $VERSION );
+    my $ca_pinning_status = $self->{enable_ca_pinning} ? 'enabled' : 'disabled';
+    $req->header('User-Agent' => "$APP_NAME/$VERSION ca_bundle/$CA_BUNDLE_VERSION (ca_pinning=$ca_pinning_status)");
 
     if (grep(/^$method$/, qw(POST PUT))) {
         $req->header('Content-type' => 'application/x-www-form-urlencoded');

--- a/t/api_calls.t
+++ b/t/api_calls.t
@@ -457,6 +457,24 @@ describe "A duo api client" => sub {
             is($captured_ssl_opts{verify_hostname}, 1);
         };
     };
+
+    describe "user agent string" => sub {
+
+        it "includes ca_bundle version and ca_pinning=enabled by default" => sub {
+            my $res = $sut->json_api_call('GET', '/admin/v1/admins', {});
+            my $ua_header = $last_captured_req->header('User-Agent');
+            my $expected = "duo_api_perl/$Duo::API::VERSION ca_bundle/$Duo::API::CA_BUNDLE_VERSION (ca_pinning=enabled)";
+            is($ua_header, $expected);
+        };
+
+        it "includes ca_pinning=disabled when CA pinning is disabled" => sub {
+            my $client = Duo::API->new($ikey, $skey, $host, undef, undef, 0);
+            $client->json_api_call('GET', '/admin/v1/admins', {});
+            my $ua_header = $last_captured_req->header('User-Agent');
+            my $expected = "duo_api_perl/$Duo::API::VERSION ca_bundle/$Duo::API::CA_BUNDLE_VERSION (ca_pinning=disabled)";
+            is($ua_header, $expected);
+        };
+    };
 };
 
 describe "test" => sub {


### PR DESCRIPTION
## Description
Add CA bundle version and CA pinning status to the User-Agent header string. The User-Agent now reports duo_api_perl/<VERSION> ca_bundle/<CA_BUNDLE_VERSION> (ca_pinning=enabled|disabled) to provide visibility into the client's runtime TLS configuration.

## Motivation and Context
Downstream services and logs need to identify which CA bundle version a client is using and whether CA pinning is active. Including this information in the User-Agent string enables easier debugging and auditing of TLS configuration across deployments

## How Has This Been Tested?
Unit tests added in t/api_calls.t verifying:
 - User-Agent includes ca_bundle/<version> and ca_pinning=enabled by default
 - User-Agent includes ca_pinning=disabled when CA pinning is explicitly turned off
 
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
